### PR TITLE
Mirror front camera

### DIFF
--- a/HybridCamLib/src/cam/CamView+Action+Core.swift
+++ b/HybridCamLib/src/cam/CamView+Action+Core.swift
@@ -50,7 +50,7 @@ extension CamView {
             onVideoCaptureComplete(nil, error)
          }
       }
-      connection.isVideoMirrored = (connection.isVideoMirroringSupported && device.position == .front)
+      connection.isVideoMirrored = (connection.isVideoMirroringSupported && device.position == .front && mirrorFrontCamera)
       guard let outputURL: URL = CamUtil.tempURL() else { onVideoCaptureComplete(nil, CaptureError.noTempFolderAccess); return }
       videoOutput.startRecording(to: outputURL, recordingDelegate: self)
    }

--- a/HybridCamLib/src/cam/CamView+Action+Core.swift
+++ b/HybridCamLib/src/cam/CamView+Action+Core.swift
@@ -50,11 +50,7 @@ extension CamView {
             onVideoCaptureComplete(nil, error)
          }
       }
-      if connection.isVideoMirroringSupported {
-         if device.position == .front {
-            connection.isVideoMirrored = true
-         }
-      }
+      connection.isVideoMirrored = (connection.isVideoMirroringSupported && device.position == .front)
       guard let outputURL: URL = CamUtil.tempURL() else { onVideoCaptureComplete(nil, CaptureError.noTempFolderAccess); return }
       videoOutput.startRecording(to: outputURL, recordingDelegate: self)
    }

--- a/HybridCamLib/src/cam/CamView+Action+Core.swift
+++ b/HybridCamLib/src/cam/CamView+Action+Core.swift
@@ -50,10 +50,11 @@ extension CamView {
             onVideoCaptureComplete(nil, error)
          }
       }
-      
-    if connection.isVideoMirroringSupported {
-        connection.isVideoMirrored = true
-    }
+      if connection.isVideoMirroringSupported {
+         if device.position == .front {
+            connection.isVideoMirrored = true
+         }
+      }
       guard let outputURL: URL = CamUtil.tempURL() else { onVideoCaptureComplete(nil, CaptureError.noTempFolderAccess); return }
       videoOutput.startRecording(to: outputURL, recordingDelegate: self)
    }

--- a/HybridCamLib/src/cam/CamView+Action+Core.swift
+++ b/HybridCamLib/src/cam/CamView+Action+Core.swift
@@ -50,6 +50,10 @@ extension CamView {
             onVideoCaptureComplete(nil, error)
          }
       }
+      
+    if connection.isVideoMirroringSupported {
+        connection.isVideoMirrored = true
+    }
       guard let outputURL: URL = CamUtil.tempURL() else { onVideoCaptureComplete(nil, CaptureError.noTempFolderAccess); return }
       videoOutput.startRecording(to: outputURL, recordingDelegate: self)
    }

--- a/HybridCamLib/src/cam/CamView+Setup.swift
+++ b/HybridCamLib/src/cam/CamView+Setup.swift
@@ -55,11 +55,6 @@ extension CamView {
          if connection.isVideoStabilizationSupported {/*Causes a glitch on enabled*/
             connection.preferredVideoStabilizationMode = .auto
          }
-        connection.isVideoMirroringSupported {
-            if deviceInput?.device.position == .front {
-                connection.isVideoMirrored = true
-            }
-        }
       } else {
           throw SetupError.unableToAddVideoOutput
       }

--- a/HybridCamLib/src/cam/CamView+Setup.swift
+++ b/HybridCamLib/src/cam/CamView+Setup.swift
@@ -10,7 +10,7 @@ extension CamView {
     */
    @objc open func setupDevice() {
       do {
-         try setupCaptureDeviceInput(cameraType: .back)
+         try setupCaptureDeviceInput(cameraType: .front) //used to be .back
          try setupVideoCamera()
          try setupMicrophone()
          try setupPhotoCamera()

--- a/HybridCamLib/src/cam/CamView+Setup.swift
+++ b/HybridCamLib/src/cam/CamView+Setup.swift
@@ -55,6 +55,11 @@ extension CamView {
          if connection.isVideoStabilizationSupported {/*Causes a glitch on enabled*/
             connection.preferredVideoStabilizationMode = .auto
          }
+        connection.isVideoMirroringSupported {
+            if deviceInput?.device.position == .front {
+                connection.isVideoMirrored = true
+            }
+        }
       } else {
           throw SetupError.unableToAddVideoOutput
       }

--- a/HybridCamLib/src/cam/CamView.swift
+++ b/HybridCamLib/src/cam/CamView.swift
@@ -33,4 +33,7 @@ open class CamView: UIView {
    public required init?(coder aDecoder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
    }
+    
+   //mirror front camera?
+   public var mirrorFrontCamera = true
 }


### PR DESCRIPTION
This little one-liner mirrors the front camera videos which before didn't look like the preview while recording (what I was talking about in the issue):
`connection.isVideoMirrored = (connection.isVideoMirroringSupported && device.position == .front && mirrorFrontCamera)`
`mirrorFrontCamera` could be made accessible to the user but I didn't bother doing this since that would mean, one would also have to rewrite the `createCamView()` function, add this variable to the `HybridCamView` class and I only need it mirrored. Just an idea... Works without `mirrorFrontCamera`, too, of course. 

I also changed the standard camera to `.front`. But that's not important. 