### PR TITLE
Enable user to zoom via record button before actually recording

### DIFF
--- a/HybridCamLib/src/cam/CamView+Action+Core.swift
+++ b/HybridCamLib/src/cam/CamView+Action+Core.swift
@@ -65,7 +65,6 @@ extension CamView {
     * Zoom in when
     */
    @objc open func zoomViaRecord(addZoom: CGFloat) {
-      guard videoOutput.isRecording else { onVideoCaptureComplete(nil, CaptureError.alreadyStoppedRecording); return } //Fixme: New error needed?
       setZoom(zoomFactor: startingZoomFactorForLongPress + addZoom) // Fixme: After going back to camView after seeing recorded video, reset zoom: setZoom(zoomFactor: 1) needs to be called and startingZoomFactorForLongPress = 1
    }
 }


### PR DESCRIPTION
I removed an unnecessary condition because it led to unintended errors when trying to zoom using the long-press gesture even though one wasn't yet actually recording. 